### PR TITLE
typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create a new python environment & install requirements
 
 ```shell script
 python -m venv en
-source env/bin/activate
+source en/bin/activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
- source the environment `en` 
- the shell commands work for me only with this proposed fix.